### PR TITLE
remove extraneous serial.begin

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,7 +141,6 @@ void setup() {
 
   digitalWrite(LED_PIN, HIGH); //LED off.
 
-  Serial.begin(115200);
   initWifi();
 
   client.setServer(MQTT_SERVER, MQTT_PORT);


### PR DESCRIPTION
No need for two instances of serial.begin - causes delayed and potentially garbled serial output at startup