### PR TITLE
Use platformio library tool, and fix deprecation warning.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,6 +8,7 @@
 platform = espressif
 framework = arduino
 board = esp8285
+lib_deps = PubSubClient
 #upload_flags = --auth=UPDATE_PW
 
 [platformio]

--- a/platformio.ini
+++ b/platformio.ini
@@ -5,7 +5,7 @@
 # http://docs.platformio.org/en/stable/projectconf.html
 #
 [env:esp8285]
-platform = espressif
+platform = espressif8266
 framework = arduino
 board = esp8285
 lib_deps = PubSubClient


### PR DESCRIPTION
Allows it to compile out the pio box without any warnings or copying of pubsubclient.* files :-)